### PR TITLE
Patt/mage logic

### DIFF
--- a/cards/cards_corrected.json
+++ b/cards/cards_corrected.json
@@ -1670,7 +1670,7 @@
                 ],
                 "mainEffect": [
                     {
-                        "type": "attack",
+                        "type": "attack_oppo_buff",
                         "minRange": 1,
                         "maxRange": 3,
                         "buff": ["fire"]
@@ -1716,15 +1716,15 @@
         },
         {
             "id": "C050",
-            "name": "Shadow Clone Jutsu",
+            "name": "Trap",
             "class": "Mage",
-            "type": "Buff",
+            "type": "Special",
             "description": "",
             "speed": 5,
             "attack": 0,
             "defense": 1,
-            "range_start": 0,
-            "range_end": 0,
+            "range_start": 1,
+            "range_end": 2,
             "sprite": {
                 "x": 1800,
                 "y": 1000,
@@ -1737,9 +1737,10 @@
                 ],
                 "mainEffect": [
                     {
-                        "type": "next_multi",
-                        "minRange": 0,
-                        "maxRange": 0
+                        "type": "trap",
+                        "minRange": 1,
+                        "maxRange": 2,
+                        "buff":["fire"]
                     }
                 ],
                 "afterEffect": [

--- a/cards/cards_corrected.json
+++ b/cards/cards_corrected.json
@@ -555,10 +555,10 @@
             "effect": {
                 "beforeEffect": [
                     {
-                        "type": "oppo_buff",
+                        "type": "attack_oppo_buff",
                         "minRange": 0,
                         "maxRange": 3,
-                        "buff": "stop_movement"
+                        "buff": "block_movement"
                     }
                 ],
                 "mainEffect": [
@@ -1774,7 +1774,7 @@
                         "type": "oppo_buff",
                         "minRange": 0,
                         "maxRange": 3,
-                        "buff": "stop_movement_2"
+                        "buff": "stop_movement"
                     }
                 ],
                 "afterEffect": [

--- a/cards/cards_corrected.json
+++ b/cards/cards_corrected.json
@@ -1737,10 +1737,11 @@
                 ],
                 "mainEffect": [
                     {
-                        "type": "trap",
+                        "type": "spawn",
                         "minRange": 1,
                         "maxRange": 2,
-                        "buff":["fire"]
+                        "buff":["fire"],
+                        "spawn":"trap"
                     }
                 ],
                 "afterEffect": [

--- a/cards/cards_corrected.json
+++ b/cards/cards_corrected.json
@@ -557,7 +557,7 @@
                     {
                         "type": "oppo_buff",
                         "minRange": 0,
-                        "maxRange": 4,
+                        "maxRange": 3,
                         "buff": "stop_movement"
                     }
                 ],
@@ -1740,7 +1740,6 @@
                         "type": "spawn",
                         "minRange": 1,
                         "maxRange": 2,
-                        "buff":["fire"],
                         "spawn":"trap"
                     }
                 ],
@@ -1774,8 +1773,8 @@
                     {
                         "type": "oppo_buff",
                         "minRange": 0,
-                        "maxRange": 4,
-                        "buff": "stop_movement"
+                        "maxRange": 3,
+                        "buff": "stop_movement_2"
                     }
                 ],
                 "afterEffect": [
@@ -1785,15 +1784,15 @@
         },
         {
             "id": "C052",
-            "name": "I cast Punch (Sweet Dream)",
+            "name": "Attack Summon",
             "class": "Mage",
-            "type": "Debuff",
+            "type": "Special",
             "description": "",
             "speed": 6,
-            "attack": 1,
-            "defense": 0,
-            "range_start": 1,
-            "range_end": 1,
+            "attack": 0,
+            "defense": 2,
+            "range_start": 0,
+            "range_end": 0,
             "sprite": {
                 "x": 200,
                 "y": 1250,
@@ -1806,10 +1805,10 @@
                 ],
                 "mainEffect": [
                     {
-                        "type": "oppo_buff",
+                        "type": "spawn",
                         "minRange": 0,
-                        "maxRange": 0,
-                        "buff": "sleep"
+                        "maxRange": 3,
+                        "spawn":"attack summon"
                     }
                 ],
                 "afterEffect": [

--- a/cards/decks.json
+++ b/cards/decks.json
@@ -205,7 +205,7 @@
             "quantity": 0
         },
         {
-            "name": "I cast Punch (Sweet Dream)",
+            "name": "Attack Summon",
             "quantity": 0
         },
         {
@@ -475,7 +475,7 @@
             "quantity": 0
         },
         {
-            "name": "I cast Punch (Sweet Dream)",
+            "name": "Attack Summon",
             "quantity": 0
         },
         {
@@ -745,7 +745,7 @@
             "quantity": 0
         },
         {
-            "name": "I cast Punch (Sweet Dream)",
+            "name": "Attack Summon",
             "quantity": 0
         },
         {
@@ -1015,7 +1015,7 @@
             "quantity": 1
         },
         {
-            "name": "I cast Punch (Sweet Dream)",
+            "name": "Attack Summon",
             "quantity": 1
         },
         {

--- a/cards/decks.json
+++ b/cards/decks.json
@@ -197,7 +197,7 @@
             "quantity": 0
         },
         {
-            "name": "Shadow Clone Jutsu",
+            "name": "Trap",
             "quantity": 0
         },
         {
@@ -467,7 +467,7 @@
             "quantity": 0
         },
         {
-            "name": "Shadow Clone Jutsu",
+            "name": "Trap",
             "quantity": 0
         },
         {
@@ -737,7 +737,7 @@
             "quantity": 0
         },
         {
-            "name": "Shadow Clone Jutsu",
+            "name": "Trap",
             "quantity": 0
         },
         {
@@ -1007,7 +1007,7 @@
             "quantity": 1
         },
         {
-            "name": "Shadow Clone Jutsu",
+            "name": "Trap",
             "quantity": 1
         },
         {

--- a/main.py
+++ b/main.py
@@ -29,8 +29,11 @@ class GameMain:
                 SelectionState.MOVE: SelectMoveState(),
                 SelectionState.PUSH: SelectPushState(),
                 SelectionState.PULL: SelectPullState(),
+                SelectionState.SPAWN: SelectSpawnState(),
                 BattleState.END_PHASE: BattleEndState(),
                 BattleState.FINISH_PHASE: BattleFinishState(),
+                
+                
             },
             "rpg": {
                 RPGState.START: TutorialState(),# Add RPG start state here

--- a/spritesheet/BuffDebuff/BuffDebuff.json
+++ b/spritesheet/BuffDebuff/BuffDebuff.json
@@ -17,7 +17,7 @@
       "y": 5
     },
     {
-      "name": "can'tmove_icon",
+      "name": "cant_move_icon",
       "width": 20,
       "height": 20,
       "x": 40,

--- a/src/EnumResources.py
+++ b/src/EnumResources.py
@@ -84,3 +84,4 @@ class BuffType(Enum):
     CRIT_RATE = "CritRate"
     CRIT_DMG = "CritDmg"
     EVADE = "Evade"
+    STOP_MOVEMENT = "Stop Movement"

--- a/src/EnumResources.py
+++ b/src/EnumResources.py
@@ -16,6 +16,7 @@ class SelectionState(Enum):
     BUFF = "buff"
     PUSH = "push"
     PULL = "pull"
+    SPAWN = "spawn"
 
 class RPGState(Enum):
     START = "start"

--- a/src/Util.py
+++ b/src/Util.py
@@ -135,7 +135,11 @@ class SpriteManager:
                                 effect_buffs = effect["buff"]
                             except KeyError:
                                 effect_buffs = None
-                            temp_effect_dict[effectPeriod].append(Effect(effect_type, effect["minRange"], effect["maxRange"], effect_buffs))
+                            try:
+                                effect_spawn = effect["spawn"]
+                            except KeyError:
+                                effect_spawn = None
+                            temp_effect_dict[effectPeriod].append(Effect(effect_type, effect["minRange"], effect["maxRange"], effect_buffs, effect_spawn))
                             print(f"{effect_type}\t{effect_buffs}")
 
                 # Create the Card object for each card entry

--- a/src/battleSystem/Buff.py
+++ b/src/battleSystem/Buff.py
@@ -5,7 +5,8 @@ class Buff():
     def __init__(self, conf):
         self.name = conf.name
         self.duration = conf.duration
-        self.value = conf.value  # [1,0,0,0] == [atk,def,spd,range]
+        self.value = conf.value  # [1,0,0,0], 0 == [atk,def,spd,range]
+        self.dot_damage = conf.dot_damage
         self.imageName = conf.imageName
 
         self.x = 0
@@ -80,6 +81,8 @@ class Buff():
                         tooltip_text = f"Lose {self.name} for {self.duration} turns"
                     else:
                         tooltip_text = f"Lose {self.name} for {self.duration} turn"
+                else:
+                    tooltip_text = f"Got {self.name} for {self.duration} turn"
             
             # Use a lighter gray color to make the font look less strong
             text_surface = font.render(tooltip_text, True, (0, 0, 0)) 

--- a/src/battleSystem/Effect.py
+++ b/src/battleSystem/Effect.py
@@ -1,7 +1,8 @@
 class Effect():
-    def __init__(self, type, minRange, maxRange, buffNameList=None):
+    def __init__(self, type, minRange, maxRange, buffNameList=None, spawn = None):
         self.type = type
         self.minRange = minRange
         self.maxRange = maxRange
         self.buffNameList = buffNameList
+        self.spawn = spawn
 

--- a/src/battleSystem/FieldTile.py
+++ b/src/battleSystem/FieldTile.py
@@ -5,23 +5,45 @@ class FieldTile:
     def __init__(self, index, position):
         self.index = index  
         self.x, self.y = position
-        self.entity = None  
+        self.entity = None
+        self.second_entity = None
         self.color = (0,0,0)
         self.solid = 1
 
     def is_occupied(self):
-        return self.entity is not None
+        if self.entity:
+            return self.entity.is_occupied_field
+        else:
+            return False
+
+    def is_second_entity(self):
+        if self.second_entity:
+            return True
+        else:
+            return False
 
     def place_entity(self, entity, target_x):
-        if not self.is_occupied():  
-            self.entity = entity
-            entity.field_index = self.index 
-            if target_x == entity.x:
-                print(f'{entity.name} is idle')
-                entity.facing_left = False if entity.name == "player" else True
+        if entity.is_occupied_field:
+            if not self.is_occupied():  
+                self.entity = entity
+                entity.field_index = self.index 
+                if target_x == entity.x:
+                    print(f'{entity.name} is idle')
+                    entity.facing_left = False if entity.name == "player" else True
+        else:
+            if not self.is_second_entity():
+                print("---------- assign", entity, "to second entity -------------")
+                self.second_entity = entity
+                entity.field_index = self.index 
+                if target_x == entity.x:
+                    print(f'{entity.name} is idle')
+                    entity.facing_left = False if entity.name == "player" else True
 
     def remove_entity(self):
         self.entity = None
+
+    def remove_second_entity(self):
+        self.second_entity = None
 
     def render(self, screen):        
         # Draw the fieldTile
@@ -34,3 +56,6 @@ class FieldTile:
             for buff in self.entity.buffs:
                 if buff.is_active():
                     buff.render(screen)
+        
+        if self.second_entity:
+            self.second_entity.render(screen, rect.x, rect.y + 40)

--- a/src/battleSystem/FieldTile.py
+++ b/src/battleSystem/FieldTile.py
@@ -12,7 +12,7 @@ class FieldTile:
 
     def is_occupied(self):
         if self.entity:
-            return self.entity.is_occupied_field
+            return True
         else:
             return False
 

--- a/src/battleSystem/battleEntity/Enemy.py
+++ b/src/battleSystem/battleEntity/Enemy.py
@@ -5,7 +5,7 @@ class Enemy(Entity):
     def __init__(self, name, animationlist):
         super().__init__(name, animationlist)
         self.health = 6  # Example additional attribute for Enemy
-
+        self.type = PlayerType.ENEMY
         self.x, self.y = 1200, ENTITY_Y  # Initial position for rendering
 
     def update(self, dt):

--- a/src/battleSystem/battleEntity/Entity.py
+++ b/src/battleSystem/battleEntity/Entity.py
@@ -56,8 +56,11 @@ class Entity:
     def print_buffs(self):
         for buff in self.buffs:
             buff.print()
+    
+    def null_function():
+        pass
 
-    def move_to(self, fieldTile, field):
+    def move_to(self, fieldTile, field, action = null_function):
         if fieldTile.is_occupied():  # Check if the fieldTile is occupied
             print("fieldTile is already occupied!")
             return
@@ -70,7 +73,8 @@ class Entity:
         self.facing_left = self.target_position < self.x  # Face left if moving to a lower x
 
         self.tweening = tween.to(
-            self, "x", self.target_position, 1, "linear")  # Tween x position
+            self, "x", self.target_position, 1, "linear")# Tween x position
+        self.tweening.on_complete(action)  
 
         # Update fieldTile and position references
         if self.fieldTile_index is not None:
@@ -158,6 +162,7 @@ class Entity:
 
             # Check if the animation has finished and switch to idle if necessary
             if animation.is_finished() and self.curr_animation != "idle":
+                
                 # Automatically switch to idle animation
                 self.ChangeAnimation("idle")
                 # Update to idle animation
@@ -195,9 +200,11 @@ class Entity:
             self.curr_animation = name
             self.frame_index = 0
             self.frame_timer = 0
+            # self.on_complete = on_complete
             # Start from the beginning of the new animation
             self.animation_list[name].Refresh()
             print(f'{self.name} animation changed to {name}')
         else:
             print(
                 f'Animation {name} not found in animation list for {self.name}')
+

--- a/src/battleSystem/battleEntity/Entity.py
+++ b/src/battleSystem/battleEntity/Entity.py
@@ -9,7 +9,7 @@ g_font = pygame.font.Font(None, 36)
 
 
 class Entity:
-    def __init__(self, name, animation_list=None, health=10):
+    def __init__(self, name, animation_list=None, health=10, is_occupied_field = True, type = None):
         self.name = name
         self.fieldTile_index = None  # Keep track of which field it is on
         self.animation_list = animation_list
@@ -17,6 +17,8 @@ class Entity:
         self.frame_index = 0  # Frame index for animations
         self.frame_timer = 0  # Timer to manage frame rate
         self.frame_duration = 0.1  # Duration for each frame (adjust as needed)
+        self.is_occupied_field = is_occupied_field
+        self.type = type
 
         # Deck & Card
         self.deck = Deck()

--- a/src/battleSystem/battleEntity/Player.py
+++ b/src/battleSystem/battleEntity/Player.py
@@ -9,6 +9,7 @@ class Player(Entity):
         self.health = 30
         self.job = job
         self.x, self.y = 0, ENTITY_Y
+        self.type = PlayerType.PLAYER
 
     def update(self, dt):
         # Implement player-specific update logic here

--- a/src/battleSystem/battleEntity/SubEntity.py
+++ b/src/battleSystem/battleEntity/SubEntity.py
@@ -9,42 +9,15 @@ from src.battleSystem.Buff import Buff
 g_font = pygame.font.Font(None, 36)
 
 
-class SubEntity(Entity):
+class SubEntity(Entity): # these sub entity will attack every round if attack != 0
     def __init__(self, conf, side = PlayerType.PLAYER):
         super().__init__(conf.name,conf.animation_list, conf.health, conf.is_occupied_field)
         self.x, self.y = 0, ENTITY_Y
-        self.attack = conf.attack
-        self.duration = conf.duration
-        self.range = conf.range
-        self.side = side
-        self.is_timeout = False
-
-    # def print_stats(self):
-    #     print(f'{self.name} stats - HP: {self.health}, ATK: {self.attack}')
-
-    # def display_stats(self):
-    #     pass
-
-    # def reset_stats(self):
-    #     pass
-
-    # def print_buffs(self):
-    #     pass
-
-    # def move_to(self, fieldTile, field):
-    #     pass
-
-    # def add_buff(self, buffList):
-    #     pass
-       
-    # def apply_buffs_to_cardsOnHand(self):
-    #     pass
-
-    # def select_card(self, card):
-    #     pass
-
-    # def remove_selected_card(self):
-    #     pass
+        self.attack = conf.attack # default attack
+        self.duration = conf.duration # remove if duration reach 0
+        self.range = conf.range # range for attacking
+        self.side = side # player or enemy side (base on who summon)
+        self.is_timeout = False # is_timeout is for removing itself after finishing animation
 
     def next_turn(self):
         self.duration -= 1
@@ -57,18 +30,17 @@ class SubEntity(Entity):
         self.index = index
 
     def remove_self(self):
-        print("set duration to 0")
         self.duration = 0
 
     def collide(self, target):
         if self.name == "trap":
-            # if target.type != self.side:
+            if target.type != self.side:
                 # mock animation
                 buff = Buff(CARD_BUFF["fire"])
                 target.add_buff(buff)
                 self.ChangeAnimation('attack', True)
-                target.ChangeAnimation('knock_down')
-        if self.name == "pheonix":
+                target.ChangeAnimation('death')
+        if self.name == "attack summon":
             if target.type != self.side:
                 target.health -= 1
                 if target.type == PlayerType.ENEMY:
@@ -78,22 +50,21 @@ class SubEntity(Entity):
 
     def bot_action(self, field):
         if self.attack != 0:
-            for tile in field[self.index - self.range :  self.index + self.range + 1]:
+            for tile in field[self.fieldTile_index - self.range :  self.fieldTile_index + self.range + 1]:
                 if tile.is_occupied() and tile.entity.type != self.side:
-                    # should render attack animation here
                     damage = self.attack - tile.entity.defense
                     if damage > 0:
                         # ATTACK HIT
                         tile.entity.ChangeAnimation("death")
-                        gSounds['attack'].play()
                         tile.entity.health -= damage
                         print(f'{tile.entity} takes {damage} damage')
+                    gSounds['attack'].play()
+                    self.ChangeAnimation("attack")
+                    print("summon attack")
 
 
 
     def update(self, dt):
-        # super().update(dt)
-        # Update the tween if it exists
         if self.tweening:
             self.tweening._update(dt)  # Tween progress
 
@@ -113,65 +84,7 @@ class SubEntity(Entity):
 
     def render(self, screen, x, y, color=(255, 0, 0)):
         super().render(screen, x, y, color)
-        # # Use tweened x, y position if tween is in progress
-        # render_x, render_y = (self.x, self.y) if self.tweening else (x, y)
 
-        # # Define entity size
-        # entity_width, entity_height = 80, 80  # Example entity size
-
-        # # Calculate centered position within the field
-        # # Center horizontally
-        # entity_x = render_x + (FIELD_WIDTH - entity_width) // 2
-        # # Center vertically
-        # entity_y = render_y + (FIELD_HEIGHT - entity_height) // 2
-
-        # # Define adjustable offsets for player and enemy
-        # offset_x = -55 if self.name == 'player' else -185
-        # offset_y = -20 if self.name == 'player' else -185
-
-        # # Update animation frame
-        # if self.animation_list and self.curr_animation in self.animation_list:
-        #     # Retrieve frames from the animation object
-        #     animation = self.animation_list[self.curr_animation]
-        #     animation_frames = animation.get_frames()
-
-        #     # Check if the animation has finished and switch to idle if necessary
-        #     if animation.is_finished() and self.curr_animation != "idle":
-        #         print(self.on_complete, "------------------ this is on complete")
-        #         # if self.on_complete:
-        #         #     self.on_complete()
-        #         #     self.on_complete = None
-        #         # Automatically switch to idle animation
-        #         self.ChangeAnimation("idle")
-        #         # Update to idle animation
-        #         animation = self.animation_list[self.curr_animation]
-        #         animation_frames = animation.get_frames()  # Update frames
-
-        #     if animation_frames:
-        #         # Update frame index based on the timer
-        #         self.frame_timer += 0.01  # Increase by seconds elapsed
-        #         if self.frame_timer >= self.frame_duration:
-        #             self.frame_timer = 0
-        #             self.frame_index = (
-        #                 self.frame_index + 1) % len(animation_frames)
-
-        #         # Render current animation frame with offsets applied
-        #         current_frame = animation_frames[self.frame_index]
-        #         screen.blit(
-        #             pygame.transform.flip(
-        #                 current_frame, self.facing_left, False),
-        #             (entity_x + offset_x, entity_y + offset_y)
-        #         )
-
-        # else:
-        #     # Placeholder red rectangle if no animation is provided
-        #     pygame.draw.rect(
-        #         screen, color, (entity_x, entity_y, entity_width, entity_height))
-
-        # # Render Buff Icons
-        # for index, buff in enumerate(self.buffs):
-        #     buff.x = entity_x + index * 20
-        #     buff.render(screen)
 
     def ChangeAnimation(self, name, is_timout = False):
         if name in self.animation_list:

--- a/src/battleSystem/battleEntity/SubEntity.py
+++ b/src/battleSystem/battleEntity/SubEntity.py
@@ -17,46 +17,64 @@ class SubEntity(Entity):
         self.duration = conf.duration
         self.range = conf.range
         self.side = side
+        self.is_timeout = False
 
-    def print_stats(self):
-        print(f'{self.name} stats - HP: {self.health}, ATK: {self.attack}')
+    # def print_stats(self):
+    #     print(f'{self.name} stats - HP: {self.health}, ATK: {self.attack}')
 
-    def display_stats(self):
-        pass
+    # def display_stats(self):
+    #     pass
 
-    def reset_stats(self):
-        pass
+    # def reset_stats(self):
+    #     pass
 
-    def print_buffs(self):
-        pass
+    # def print_buffs(self):
+    #     pass
 
-    def move_to(self, fieldTile, field):
-        pass
+    # def move_to(self, fieldTile, field):
+    #     pass
 
-    def add_buff(self, buffList):
-        pass
+    # def add_buff(self, buffList):
+    #     pass
        
-    def apply_buffs_to_cardsOnHand(self):
-        pass
+    # def apply_buffs_to_cardsOnHand(self):
+    #     pass
 
-    def select_card(self, card):
-        pass
+    # def select_card(self, card):
+    #     pass
 
-    def remove_selected_card(self):
-        pass
+    # def remove_selected_card(self):
+    #     pass
 
     def next_turn(self):
-        pass # should implement something ?
+        self.duration -= 1
+        if self.duration == 0:
+            return True
+        else:
+            return False
 
     def select_position(self, index):
         self.index = index
 
-    def collide(self, target, field):
+    def remove_self(self):
+        print("set duration to 0")
+        self.duration = 0
+
+    def collide(self, target):
         if self.name == "trap":
-            if target.type != self.side:
+            # if target.type != self.side:
+                # mock animation
                 buff = Buff(CARD_BUFF["fire"])
                 target.add_buff(buff)
-                field.remove_second_entity()
+                self.ChangeAnimation('attack', True)
+                target.ChangeAnimation('knock_down')
+        if self.name == "pheonix":
+            if target.type != self.side:
+                target.health -= 1
+                if target.type == PlayerType.ENEMY:
+                    target.ChangeAnimation('death')
+                    gSounds['attack'].play()
+                self.ChangeAnimation('attack', True)
 
     def bot_action(self, field):
         if self.attack != 0:
@@ -74,22 +92,24 @@ class SubEntity(Entity):
 
 
     def update(self, dt):
-        super().update(dt)
-        # # Update the tween if it exists
-        # if self.tweening:
-        #     self.tweening._update(dt)  # Tween progress
+        # super().update(dt)
+        # Update the tween if it exists
+        if self.tweening:
+            self.tweening._update(dt)  # Tween progress
 
-        # if self.target_position == self.x:
-        #     self.facing_left = False if self.name == "player" else True
+        if self.target_position == self.x:
+            self.facing_left = False if self.name == "player" else True
 
-        # # Check if an animation is set and update it
-        # if self.curr_animation in self.animation_list:
-        #     animation = self.animation_list[self.curr_animation]
-        #     animation.update(dt)  # Progress the animation with delta time
+        # Check if an animation is set and update it
+        if self.curr_animation in self.animation_list:
+            animation = self.animation_list[self.curr_animation]
+            animation.update(dt)  # Progress the animation with delta time
 
-        #     # If the animation has finished, switch to the idle animation
-        #     if animation.is_finished() and self.curr_animation != "idle":
-        #         self.ChangeAnimation("idle")
+            # If the animation has finished, switch to the idle animation
+            if animation.is_finished() and self.curr_animation != "idle":
+                if self.is_timeout:
+                    self.remove_self()
+                self.ChangeAnimation("idle")
 
     def render(self, screen, x, y, color=(255, 0, 0)):
         super().render(screen, x, y, color)
@@ -117,6 +137,10 @@ class SubEntity(Entity):
 
         #     # Check if the animation has finished and switch to idle if necessary
         #     if animation.is_finished() and self.curr_animation != "idle":
+        #         print(self.on_complete, "------------------ this is on complete")
+        #         # if self.on_complete:
+        #         #     self.on_complete()
+        #         #     self.on_complete = None
         #         # Automatically switch to idle animation
         #         self.ChangeAnimation("idle")
         #         # Update to idle animation
@@ -149,15 +173,15 @@ class SubEntity(Entity):
         #     buff.x = entity_x + index * 20
         #     buff.render(screen)
 
-    def ChangeAnimation(self, name):
-        super().ChangeAnimation(name)
-    #     if name in self.animation_list:
-    #         self.curr_animation = name
-    #         self.frame_index = 0
-    #         self.frame_timer = 0
-    #         # Start from the beginning of the new animation
-    #         self.animation_list[name].Refresh()
-    #         print(f'{self.name} animation changed to {name}')
-    #     else:
-    #         print(
-    #             f'Animation {name} not found in animation list for {self.name}')
+    def ChangeAnimation(self, name, is_timout = False):
+        if name in self.animation_list:
+            self.curr_animation = name
+            self.frame_index = 0
+            self.frame_timer = 0
+            self.is_timeout = is_timout
+            # Start from the beginning of the new animation
+            self.animation_list[name].Refresh()
+            print(f'{self.name} animation changed to {name}')
+        else:
+            print(
+                f'Animation {name} not found in animation list for {self.name}')

--- a/src/battleSystem/battleEntity/SubEntity.py
+++ b/src/battleSystem/battleEntity/SubEntity.py
@@ -1,0 +1,163 @@
+import pygame
+from src.dependency import *
+from src.battleSystem.battleEntity.Entity import Entity
+import tween
+from src.battleSystem.Buff import Buff
+
+# Define the global font variable
+# You can adjust the font size and type as needed
+g_font = pygame.font.Font(None, 36)
+
+
+class SubEntity(Entity):
+    def __init__(self, conf, side = PlayerType.PLAYER):
+        super().__init__(conf.name,conf.animation_list, conf.health, conf.is_occupied_field)
+        self.x, self.y = 0, ENTITY_Y
+        self.attack = conf.attack
+        self.duration = conf.duration
+        self.range = conf.range
+        self.side = side
+
+    def print_stats(self):
+        print(f'{self.name} stats - HP: {self.health}, ATK: {self.attack}')
+
+    def display_stats(self):
+        pass
+
+    def reset_stats(self):
+        pass
+
+    def print_buffs(self):
+        pass
+
+    def move_to(self, fieldTile, field):
+        pass
+
+    def add_buffs(self, buffList):
+        pass
+       
+    def apply_buffs_to_cardsOnHand(self):
+        pass
+
+    def select_card(self, card):
+        pass
+
+    def remove_selected_card(self):
+        pass
+
+    def next_turn(self):
+        pass # should implement something ?
+
+    def select_position(self, index):
+        self.index = index
+
+    def collide(self, target, field):
+        if self.name == "trap":
+            buffList = [Buff(CARD_BUFF["fire"])]
+            target.add_buffs(buffList)
+            print(f"apply buff {buffList} to enemy")
+            field.remove_second_entity()
+
+    def bot_action(self, field):
+        if self.attack != 0:
+            for tile in field[self.index - self.range :  self.index + self.range + 1]:
+                if tile.is_occupied() and tile.entity.type != self.side:
+                    # should render attack animation here
+                    damage = self.attack - tile.entity.defense
+                    if damage > 0:
+                        # ATTACK HIT
+                        tile.entity.ChangeAnimation("death")
+                        gSounds['attack'].play()
+                        tile.entity.health -= damage
+                        print(f'{tile.entity} takes {damage} damage')
+
+
+
+    def update(self, dt):
+        super().update(dt)
+        # # Update the tween if it exists
+        # if self.tweening:
+        #     self.tweening._update(dt)  # Tween progress
+
+        # if self.target_position == self.x:
+        #     self.facing_left = False if self.name == "player" else True
+
+        # # Check if an animation is set and update it
+        # if self.curr_animation in self.animation_list:
+        #     animation = self.animation_list[self.curr_animation]
+        #     animation.update(dt)  # Progress the animation with delta time
+
+        #     # If the animation has finished, switch to the idle animation
+        #     if animation.is_finished() and self.curr_animation != "idle":
+        #         self.ChangeAnimation("idle")
+
+    def render(self, screen, x, y, color=(255, 0, 0)):
+        super().render(screen, x, y, color)
+        # # Use tweened x, y position if tween is in progress
+        # render_x, render_y = (self.x, self.y) if self.tweening else (x, y)
+
+        # # Define entity size
+        # entity_width, entity_height = 80, 80  # Example entity size
+
+        # # Calculate centered position within the field
+        # # Center horizontally
+        # entity_x = render_x + (FIELD_WIDTH - entity_width) // 2
+        # # Center vertically
+        # entity_y = render_y + (FIELD_HEIGHT - entity_height) // 2
+
+        # # Define adjustable offsets for player and enemy
+        # offset_x = -55 if self.name == 'player' else -185
+        # offset_y = -20 if self.name == 'player' else -185
+
+        # # Update animation frame
+        # if self.animation_list and self.curr_animation in self.animation_list:
+        #     # Retrieve frames from the animation object
+        #     animation = self.animation_list[self.curr_animation]
+        #     animation_frames = animation.get_frames()
+
+        #     # Check if the animation has finished and switch to idle if necessary
+        #     if animation.is_finished() and self.curr_animation != "idle":
+        #         # Automatically switch to idle animation
+        #         self.ChangeAnimation("idle")
+        #         # Update to idle animation
+        #         animation = self.animation_list[self.curr_animation]
+        #         animation_frames = animation.get_frames()  # Update frames
+
+        #     if animation_frames:
+        #         # Update frame index based on the timer
+        #         self.frame_timer += 0.01  # Increase by seconds elapsed
+        #         if self.frame_timer >= self.frame_duration:
+        #             self.frame_timer = 0
+        #             self.frame_index = (
+        #                 self.frame_index + 1) % len(animation_frames)
+
+        #         # Render current animation frame with offsets applied
+        #         current_frame = animation_frames[self.frame_index]
+        #         screen.blit(
+        #             pygame.transform.flip(
+        #                 current_frame, self.facing_left, False),
+        #             (entity_x + offset_x, entity_y + offset_y)
+        #         )
+
+        # else:
+        #     # Placeholder red rectangle if no animation is provided
+        #     pygame.draw.rect(
+        #         screen, color, (entity_x, entity_y, entity_width, entity_height))
+
+        # # Render Buff Icons
+        # for index, buff in enumerate(self.buffs):
+        #     buff.x = entity_x + index * 20
+        #     buff.render(screen)
+
+    def ChangeAnimation(self, name):
+        super().ChangeAnimation(name)
+    #     if name in self.animation_list:
+    #         self.curr_animation = name
+    #         self.frame_index = 0
+    #         self.frame_timer = 0
+    #         # Start from the beginning of the new animation
+    #         self.animation_list[name].Refresh()
+    #         print(f'{self.name} animation changed to {name}')
+    #     else:
+    #         print(
+    #             f'Animation {name} not found in animation list for {self.name}')

--- a/src/battleSystem/battleEntity/SubEntity.py
+++ b/src/battleSystem/battleEntity/SubEntity.py
@@ -17,7 +17,7 @@ class SubEntity(Entity): # these sub entity will attack every round if attack !=
         self.duration = conf.duration # remove if duration reach 0
         self.range = conf.range # range for attacking
         self.side = side # player or enemy side (base on who summon)
-        self.is_timeout = False # is_timeout is for removing itself after finishing animation
+        self.remove_flag = False # remove flag is for removing itself after finishing animation
 
     def next_turn(self):
         self.duration -= 1
@@ -28,6 +28,13 @@ class SubEntity(Entity): # these sub entity will attack every round if attack !=
 
     def select_position(self, index):
         self.index = index
+    
+    def take_damage(self, damage):
+        self.health -= damage
+        if self.health > 0:
+            self.ChangeAnimation("death")
+        else:
+            self.ChangeAnimation("death", True)
 
     def remove_self(self):
         self.duration = 0
@@ -78,7 +85,7 @@ class SubEntity(Entity): # these sub entity will attack every round if attack !=
 
             # If the animation has finished, switch to the idle animation
             if animation.is_finished() and self.curr_animation != "idle":
-                if self.is_timeout:
+                if self.remove_flag:
                     self.remove_self()
                 self.ChangeAnimation("idle")
 
@@ -86,12 +93,12 @@ class SubEntity(Entity): # these sub entity will attack every round if attack !=
         super().render(screen, x, y, color)
 
 
-    def ChangeAnimation(self, name, is_timout = False):
+    def ChangeAnimation(self, name, remove_flag = False):
         if name in self.animation_list:
             self.curr_animation = name
             self.frame_index = 0
             self.frame_timer = 0
-            self.is_timeout = is_timout
+            self.remove_flag = remove_flag
             # Start from the beginning of the new animation
             self.animation_list[name].Refresh()
             print(f'{self.name} animation changed to {name}')

--- a/src/battleSystem/battleEntity/entity_defs.py
+++ b/src/battleSystem/battleEntity/entity_defs.py
@@ -1,0 +1,21 @@
+import pygame
+from src.dependency import *
+from src.battleSystem.Deck import Deck
+import tween
+
+
+class SubEntityConf:
+    def __init__(self, name, animation_list=None, health=10, is_occupied_field = False, attack = 1, duration = -1, range = 1):
+        self.name = name
+        self.animation_list = animation_list
+        self.is_occupied_field = is_occupied_field
+        self.health = health
+        self.attack = attack
+        self.duration = duration
+        self.range = range
+
+
+SUB_ENTITY = {
+    "trap" : SubEntityConf("trap", gEntity_animation_dict["goblin"], 1, False, 0, 3, 0),
+}
+

--- a/src/battleSystem/battleEntity/sub_entity_defs.py
+++ b/src/battleSystem/battleEntity/sub_entity_defs.py
@@ -16,6 +16,7 @@ class SubEntityConf:
 
 
 SUB_ENTITY = {
-    "trap" : SubEntityConf("trap", gEntity_animation_dict["goblin"], 1, False, 0, 3, 0), # please find some animation for the trap replace goblin for me please.
+    "trap" : SubEntityConf("trap", gEntity_animation_dict["goblin"], 1, False, 0, 2, 0), # please find some animation for the trap replace goblin for me please.
+    "pheonix": SubEntityConf("pheonix", gEntity_animation_dict["goblin"], 4, False, 1, 5, 2)
 }
 

--- a/src/battleSystem/battleEntity/sub_entity_defs.py
+++ b/src/battleSystem/battleEntity/sub_entity_defs.py
@@ -17,6 +17,6 @@ class SubEntityConf:
 
 SUB_ENTITY = {
     "trap" : SubEntityConf("trap", gEntity_animation_dict["goblin"], 1, False, 0, 2, 0), # please find some animation for the trap replace goblin for me please.
-    "pheonix": SubEntityConf("pheonix", gEntity_animation_dict["goblin"], 4, False, 1, 5, 2)
+    "attack summon": SubEntityConf("attack summon", gEntity_animation_dict["goblin"], 4, False, 1, 5, 2)
 }
 

--- a/src/battleSystem/buff_def.py
+++ b/src/battleSystem/buff_def.py
@@ -2,78 +2,78 @@ from src.resources import *
 from src.EnumResources import BuffType
 
 class BuffConf:
-    def __init__(self, name, description, duration, type, value, dot_damage, imageName=None):
+    def __init__(self, name, description, duration, type, value, imageName=None, dot_damage=0):
         self.name = name
         self.description = description
         self.duration = duration
         self.type = type
-        self.dot_damage = dot_damage
         self.value = value  # [1,0,0,0] == [atk,def,spd,range]
         self.imageName = imageName
+        self.dot_damage = dot_damage
 
 
 DICE_ROLL_BUFF = {
-    0: BuffConf("Bonus Attack Buff", "Bonus +1 ATK", 1, BuffType.DICE_ROLL, [1, 0, 0, 0], 0, gBuffIcon_image_list["attack"]),
-    1: BuffConf("Bonus Defense Buff", "Bonus +1 DEF", 1, BuffType.DICE_ROLL, [0, 1, 0, 0], 0, gBuffIcon_image_list["defense"]),
-    2: BuffConf("Bonus Speed Buff", "Bonus +1 SPD", 1, BuffType.DICE_ROLL, [0, 0, 1, 0], 0, gBuffIcon_image_list["speed"]),
+    0: BuffConf("Bonus Attack Buff", "Bonus +1 ATK", 1, BuffType.DICE_ROLL, [1, 0, 0, 0], gBuffIcon_image_list["attack"]),
+    1: BuffConf("Bonus Defense Buff", "Bonus +1 DEF", 1, BuffType.DICE_ROLL, [0, 1, 0, 0], gBuffIcon_image_list["defense"]),
+    2: BuffConf("Bonus Speed Buff", "Bonus +1 SPD", 1, BuffType.DICE_ROLL, [0, 0, 1, 0], gBuffIcon_image_list["speed"]),
 }
 
 CARD_BUFF = {
     "attack_boost": BuffConf(
-        "Attack Boost", "+2 ATK", 2, BuffType.BUFF, [2, 0, 0, 0], 0, gBuffIcon_image_list["attack"]
+        "Attack Boost", "+2 ATK", 2, BuffType.BUFF, [2, 0, 0, 0], gBuffIcon_image_list["attack"]
     ),
     "defense_boost": BuffConf(
-        "Defense Boost", "+2 DEF", 2, BuffType.BUFF, [0, 2, 0, 0], 0, gBuffIcon_image_list["defense"]
+        "Defense Boost", "+2 DEF", 2, BuffType.BUFF, [0, 2, 0, 0], gBuffIcon_image_list["defense"]
     ),
     "speed_boost": BuffConf(
-        "Speed Boost", "+2 SPD", 2, BuffType.BUFF, [0, 0, 2, 0], 0, gBuffIcon_image_list["speed"]
+        "Speed Boost", "+2 SPD", 2, BuffType.BUFF, [0, 0, 2, 0], gBuffIcon_image_list["speed"]
     ),
     "range_boost": BuffConf(
-        "Range Boost", "+1 RANGE", 2, BuffType.BUFF, [0, 0, 0, 1], 0, gBuffIcon_image_list["range"]
+        "Range Boost", "+1 RANGE", 2, BuffType.BUFF, [0, 0, 0, 1], gBuffIcon_image_list["range"]
     ),
     "perm_attack_boost": BuffConf(
-        "Permanent Attack Boost", "+1 ATK & -1 SPD", -1, BuffType.PERM_BUFF, [1, 0, -1, 0], 0, gBuffIcon_image_list["attack"]
+        "Permanent Attack Boost", "+1 ATK & -1 SPD", -1, BuffType.PERM_BUFF, [1, 0, -1, 0], gBuffIcon_image_list["attack"]
     ),
     "perm_defense_boost": BuffConf(
-        "Permanent Defense Boost", "+1 DEF & -1 ATK", -1, BuffType.PERM_BUFF, [-1, 1, 0, 0], 0, gBuffIcon_image_list["defense"]
+        "Permanent Defense Boost", "+1 DEF & -1 ATK", -1, BuffType.PERM_BUFF, [-1, 1, 0, 0], gBuffIcon_image_list["defense"]
     ),
     "perm_speed_boost": BuffConf(
-        "Permanent Speed Boost", "+1 SPD & -1 DEF", -1, BuffType.PERM_BUFF, [0, -1, 1, 0], 0, gBuffIcon_image_list["speed"]
+        "Permanent Speed Boost", "+1 SPD & -1 DEF", -1, BuffType.PERM_BUFF, [0, -1, 1, 0], gBuffIcon_image_list["speed"]
     ),
     "attack_debuff": BuffConf(
-        "Attack Debuff", "-2 ATK", 2, BuffType.DEBUFF, [-2, 0, 0, 0], 0, gBuffIcon_image_list["attack"]
+        "Attack Debuff", "-2 ATK", 2, BuffType.DEBUFF, [-2, 0, 0, 0], gBuffIcon_image_list["attack"]
     ),
     "defense_debuff": BuffConf(
-        "Defense Debuff", "-2 DEF", 2, BuffType.DEBUFF, [0, -2, 0, 0], 0, gBuffIcon_image_list["defense"]
+        "Defense Debuff", "-2 DEF", 2, BuffType.DEBUFF, [0, -2, 0, 0], gBuffIcon_image_list["defense"]
     ),
     "speed_debuff": BuffConf(
-        "Speed Debuff", "-2 SPD", 2, BuffType.DEBUFF, [0, 0, -2, 0], 0, gBuffIcon_image_list["speed"]
+        "Speed Debuff", "-2 SPD", 2, BuffType.DEBUFF, [0, 0, -2, 0], gBuffIcon_image_list["speed"]
     ),
     "range_debuff": BuffConf(
-        "Range Debuff", "-2 RANGE", 2, BuffType.DEBUFF, [0, 0, 0, -2], 0, gBuffIcon_image_list["range"]
+        "Range Debuff", "-2 RANGE", 2, BuffType.DEBUFF, [0, 0, 0, -2], gBuffIcon_image_list["range"]
     ),
     "empower": BuffConf(
-        "Empower", "Empower (+1 ATK & +1 DEF)", 2, BuffType.EMPOWER, [1, 0, 0, 0], 0, gBuffIcon_image_list["defense"]
+        "Empower", "Empower (+1 ATK & +1 DEF)", 2, BuffType.EMPOWER, [1, 0, 0, 0], gBuffIcon_image_list["defense"]
     ),
     "blood_buff": BuffConf(
-        "Blood Buff", "Increase ATK by 30% of HP", 1, BuffType.BLOOD, [0, 0, 0, 0], 0, gBuffIcon_image_list["attack"]
+        "Blood Buff", "Increase ATK by 30% of HP", 1, BuffType.BLOOD, [0, 0, 0, 0], gBuffIcon_image_list["attack"]
     ),
     "crit+": BuffConf(
-        "Critical+", "Increase Critical Chance to 4/6", 2, BuffType.CRIT_RATE, [0, 0, 0, 0], 0, gBuffIcon_image_list["critical"]
+        "Critical+", "Increase Critical Chance to 4/6", 2, BuffType.CRIT_RATE, [0, 0, 0, 0], gBuffIcon_image_list["critical"]
     ),
     "critical_buff": BuffConf(
-        "Critical Damage", "Critical (x1.5 ATK)", 1, BuffType.CRIT_DMG, [0, 0, 0, 0], 0, gBuffIcon_image_list["critical"]
+        "Critical Damage", "Critical (x1.5 ATK)", 1, BuffType.CRIT_DMG, [0, 0, 0, 0], gBuffIcon_image_list["critical"]
     ),
     "confuse": BuffConf(
-        "Confusion", "Randomly Choose Tile", 1, BuffType.DEBUFF, [0, 0, 0, 0], 0, gBuffIcon_image_list["range"]
+        "Confusion", "Randomly Choose Tile", 1, BuffType.DEBUFF, [0, 0, 0, 0], gBuffIcon_image_list["range"]
     ),
     'fire': BuffConf(
         'Fire', "Deal 1 damage per turn", 3, BuffType.DEBUFF, [0, 0, 0, 0], -1, gBuffIcon_image_list['debuff']
     ),
     'block_movement': BuffConf(
-        'Block Movement', "Can not use move effect", 2, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], 0, gBuffIcon_image_list['cant_move']
+        'Block Movement', "Can not use move effect", 2, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], gBuffIcon_image_list['cant_move']
     ),
     'stop_movement': BuffConf(
-        'Stop Movement', "Can not use move effect", 10, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], 0, gBuffIcon_image_list['cant_move']
+        'Stop Movement', "Can not use move effect", 10, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], gBuffIcon_image_list['cant_move']
     ),
 }

--- a/src/battleSystem/buff_def.py
+++ b/src/battleSystem/buff_def.py
@@ -68,7 +68,7 @@ CARD_BUFF = {
         "Confusion", "Randomly Choose Tile", 1, BuffType.DEBUFF, [0, 0, 0, 0], gBuffIcon_image_list["range"]
     ),
     'fire': BuffConf(
-        'Fire', "Deal 1 damage per turn", 3, BuffType.DEBUFF, [0, 0, 0, 0], -1, gBuffIcon_image_list['debuff']
+        'Fire', "Deal 1 damage per turn", 3, BuffType.DEBUFF, [0, 0, 0, 0], gBuffIcon_image_list['fire'], -1
     ),
     'block_movement': BuffConf(
         'Block Movement', "Can not use move effect", 2, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], gBuffIcon_image_list['cant_move']

--- a/src/battleSystem/buff_def.py
+++ b/src/battleSystem/buff_def.py
@@ -71,6 +71,9 @@ CARD_BUFF = {
         'Fire', "Deal 1 damage per turn", 3, BuffType.DEBUFF, [0, 0, 0, 0], -1, gBuffIcon_image_list['debuff']
     ),
     'stop_movement': BuffConf(
-        'Stop Movement', "Can not use move effect", 2, BuffType.DEBUFF, [0, 0, 0, 0], 0, gBuffIcon_image_list['debuff']
+        'Stop Movement', "Can not use move effect", 2, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], 0, gBuffIcon_image_list['debuff']
+    ),
+    'stop_movement_2': BuffConf(
+        'Stop Movement 2', "Can not use move effect", 10, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], 0, gBuffIcon_image_list['debuff']
     ),
 }

--- a/src/battleSystem/buff_def.py
+++ b/src/battleSystem/buff_def.py
@@ -1,34 +1,37 @@
 from src.resources import *
 
 class BuffConf():
-    def __init__(self, name, duration, value, imageName=None):
+    def __init__(self, name, duration, value, dot_damage, imageName=None):
         self.name = name
         self.duration = duration
-        self.value = value  # [1,0,0,0] == [atk,def,spd,range]
+        self.value = value  # [1,0,0,0], 0 == [atk,def,spd,range]
+        self.dot_damage = dot_damage
         self.imageName = imageName
 
 DICE_ROLL_BUFF = {
-    0: BuffConf('Bonus +1 ATK', 1, [1, 0, 0, 0], gBuffIcon_image_list['attack']),
-    1: BuffConf('Bonus +1 DEF', 1, [0, 1, 0, 0], gBuffIcon_image_list['defense']),
-    2: BuffConf('Bonus +1 SPD', 1, [0, 0, 1, 0], gBuffIcon_image_list['speed']),
+    0: BuffConf('Bonus +1 ATK', 1, [1, 0, 0, 0], 0, gBuffIcon_image_list['attack']),
+    1: BuffConf('Bonus +1 DEF', 1, [0, 1, 0, 0], 0, gBuffIcon_image_list['defense']),
+    2: BuffConf('Bonus +1 SPD', 1, [0, 0, 1, 0], 0, gBuffIcon_image_list['speed']),
 }
 
 CARD_BUFF = {
-    'attack_boost': BuffConf('+2 ATK', 2, [2, 0, 0, 0], gBuffIcon_image_list['attack']),
-    'defense_boost': BuffConf('+2 DEF', 2, [0, 2, 0, 0], gBuffIcon_image_list['defense']),
-    'speed_boost': BuffConf('+2 SPD', 2, [0, 0, 2, 0], gBuffIcon_image_list['speed']),
-    'range_boost': BuffConf('+2 RANGE', 2, [0, 0, 0, 2], gBuffIcon_image_list['range']),
-    'perm_attack_boost_1': BuffConf('+1 ATK', -1, [1, 0, 0, 0], gBuffIcon_image_list['attack']),
-    'perm_attack_boost_2': BuffConf('-1 SPD', -1, [0, 0, -1, 0], gBuffIcon_image_list['speed']),
-    'perm_defense_boost_1': BuffConf('+1 DEF', -1, [0, 1, 0, 0], gBuffIcon_image_list['defense']),
-    'perm_defense_boost_2': BuffConf('-1 ATK', -1, [-1, 0, 0, 0], gBuffIcon_image_list['attack']),
-    'perm_speed_boost_1': BuffConf('+1 SPD', -1, [0, 0, 1, 0], gBuffIcon_image_list['speed']),
-    'perm_speed_boost_2': BuffConf('-1 DEF', -1, [0, -1, 0, 0], gBuffIcon_image_list['defense']),
-    'attack_debuff': BuffConf('-2 ATK', 2, [-2, 0, 0, 0], gBuffIcon_image_list['attack']),
-    'defense_debuff': BuffConf('-2 DEF', 2, [0, -2, 0, 0], gBuffIcon_image_list['defense']),
-    'speed_debuff': BuffConf('-2 SPD', 2, [0, 0, -2, 0], gBuffIcon_image_list['speed']),
-    'range_debuff': BuffConf('-2 RANGE', 2, [0, 0, 0, -2], gBuffIcon_image_list['range']),
-    'empower_1': BuffConf('Empower (+1 ATK)', 2, [1, 0, 0, 0], gBuffIcon_image_list['attack']),
-    'empower_2': BuffConf('Empower (+1 DEF)', 2, [0, 1, 0, 0], gBuffIcon_image_list['defense']),
-    'blood_buff': BuffConf('Blood Buff', 1,[1, 0, 0, 0], gBuffIcon_image_list['attack']),
+    'attack_boost': BuffConf('+2 ATK', 2, [2, 0, 0, 0], 0, gBuffIcon_image_list['attack']),
+    'defense_boost': BuffConf('+2 DEF', 2, [0, 2, 0, 0], 0, gBuffIcon_image_list['defense']),
+    'speed_boost': BuffConf('+2 SPD', 2, [0, 0, 2, 0], 0, gBuffIcon_image_list['speed']),
+    'range_boost': BuffConf('+2 RANGE', 2, [0, 0, 0, 2], 0, gBuffIcon_image_list['range']),
+    'perm_attack_boost_1': BuffConf('+1 ATK', -1, [1, 0, 0, 0], 0, gBuffIcon_image_list['attack']),
+    'perm_attack_boost_2': BuffConf('-1 SPD', -1, [0, 0, -1, 0], 0, gBuffIcon_image_list['speed']),
+    'perm_defense_boost_1': BuffConf('+1 DEF', -1, [0, 1, 0, 0], 0, gBuffIcon_image_list['defense']),
+    'perm_defense_boost_2': BuffConf('-1 ATK', -1, [-1, 0, 0, 0], 0, gBuffIcon_image_list['attack']),
+    'perm_speed_boost_1': BuffConf('+1 SPD', -1, [0, 0, 1, 0], 0, gBuffIcon_image_list['speed']),
+    'perm_speed_boost_2': BuffConf('-1 DEF', -1, [0, -1, 0, 0], 0, gBuffIcon_image_list['defense']),
+    'attack_debuff': BuffConf('-2 ATK', 2, [-2, 0, 0, 0], 0, gBuffIcon_image_list['attack']),
+    'defense_debuff': BuffConf('-2 DEF', 2, [0, -2, 0, 0], 0, gBuffIcon_image_list['defense']),
+    'speed_debuff': BuffConf('-2 SPD', 2, [0, 0, -2, 0], 0, gBuffIcon_image_list['speed']),
+    'range_debuff': BuffConf('-2 RANGE', 2, [0, 0, 0, -2], 0, gBuffIcon_image_list['range']),
+    'empower_1': BuffConf('Empower (+1 ATK)', 2, [1, 0, 0, 0], 0, gBuffIcon_image_list['attack']),
+    'empower_2': BuffConf('Empower (+1 DEF)', 2, [0, 1, 0, 0], 0, gBuffIcon_image_list['defense']),
+    'blood_buff': BuffConf('Blood Buff', 1,[1, 0, 0, 0], 0, gBuffIcon_image_list['attack']),
+    'fire': BuffConf('Fire', 3,[0, 0, 0, 0], -1, gBuffIcon_image_list['debuff']),
+    'stop_movement': BuffConf('Stop Movement', 2,[0, 0, 0, 0], 0, gBuffIcon_image_list['debuff']),
 }

--- a/src/battleSystem/buff_def.py
+++ b/src/battleSystem/buff_def.py
@@ -70,10 +70,10 @@ CARD_BUFF = {
     'fire': BuffConf(
         'Fire', "Deal 1 damage per turn", 3, BuffType.DEBUFF, [0, 0, 0, 0], -1, gBuffIcon_image_list['debuff']
     ),
-    'stop_movement': BuffConf(
-        'Stop Movement', "Can not use move effect", 2, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], 0, gBuffIcon_image_list['debuff']
+    'block_movement': BuffConf(
+        'Block Movement', "Can not use move effect", 2, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], 0, gBuffIcon_image_list['cant_move']
     ),
-    'stop_movement_2': BuffConf(
-        'Stop Movement 2', "Can not use move effect", 10, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], 0, gBuffIcon_image_list['debuff']
+    'stop_movement': BuffConf(
+        'Stop Movement', "Can not use move effect", 10, BuffType.STOP_MOVEMENT, [0, 0, 0, 0], 0, gBuffIcon_image_list['cant_move']
     ),
 }

--- a/src/dependency.py
+++ b/src/dependency.py
@@ -2,7 +2,7 @@ import pygame
 from src.constants import *
 from src.resources import *
 from src.battleSystem.buff_def import *
-from src.battleSystem.battleEntity.entity_defs import SUB_ENTITY
+from src.battleSystem.battleEntity.sub_entity_defs import SUB_ENTITY
 from src.EnumResources import *
 
 from src.StateMachine import StateMachine

--- a/src/dependency.py
+++ b/src/dependency.py
@@ -2,6 +2,7 @@ import pygame
 from src.constants import *
 from src.resources import *
 from src.battleSystem.buff_def import *
+from src.battleSystem.battleEntity.entity_defs import SUB_ENTITY
 from src.EnumResources import *
 
 from src.StateMachine import StateMachine
@@ -17,10 +18,12 @@ from src.states.SelectBuffState import SelectBuffState
 from src.states.SelectMoveState import SelectMoveState
 from src.states.SelectPushState import SelectPushState
 from src.states.SelectPullState import SelectPullState
+from src.states.SelectSpawnState import SelectSpawnState
 from src.states.BattleEndState import BattleEndState
 from src.states.BattleFinishState import BattleFinishState
 from src.rpg.states.RPGStartState import RPGStartState
 from src.rpg.states.TavernMapState import TavernMapState
 from src.rpg.states.TutorialState import TutorialState
+
 
 from src.resources import gBuffIcon_image_list

--- a/src/resources.py
+++ b/src/resources.py
@@ -24,6 +24,7 @@ gBuffIcon_image_list = {
     "range": sprite_collection["range_icon"].image,
     "critical": sprite_collection["critical_icon"].image,
     "cant_move": sprite_collection["cant_move_icon"].image,
+    "fire": sprite_collection["fire_icon"].image,
 }
 
 gWarrior_animation_list = {

--- a/src/resources.py
+++ b/src/resources.py
@@ -10,9 +10,9 @@ CARD_DEFS = sprite_collection["card_conf"]  # dict {"name": CardConf class}
 DECK_DEFS = DeckLoader().deck_conf          # dict {"name": DeckConf class}
 
 gSounds = {
-    'dice_roll': pygame.mixer.Sound("sounds/dice_roll.mp3"),
-    'attack': pygame.mixer.Sound("sounds/attack.wav"),
-    'block': pygame.mixer.Sound("sounds/block.wav"),
+    "dice_roll": pygame.mixer.Sound("sounds/dice_roll.mp3"),
+    "attack": pygame.mixer.Sound("sounds/attack.wav"),
+    "block": pygame.mixer.Sound("sounds/block.wav"),
 }
 
 gBuffIcon_image_list = {
@@ -22,7 +22,8 @@ gBuffIcon_image_list = {
     "defense": sprite_collection["defense_icon"].image,
     "speed": sprite_collection["speed_icon"].image,
     "range": sprite_collection["range_icon"].image,
-    "critical": sprite_collection["critical_icon"].image
+    "critical": sprite_collection["critical_icon"].image,
+    "cant_move": sprite_collection["cant_move_icon"].image,
 }
 
 gWarrior_animation_list = {
@@ -32,7 +33,7 @@ gWarrior_animation_list = {
     "single_attack": sprite_collection["singleAttack_warrior"].animation,
     "idle": sprite_collection["idle_warrior"].animation,
     "knock_down": sprite_collection["knockDown_warrior"].animation,
-    "walk": sprite_collection["walk_warrior"].animation
+    "walk": sprite_collection["walk_warrior"].animation,
 }
 
 gRanger_animation_list = {
@@ -42,7 +43,7 @@ gRanger_animation_list = {
     "single_attack": sprite_collection["singleAttack_ranger"].animation,
     "idle": sprite_collection["idle_ranger"].animation,
     "knock_down": sprite_collection["knockDown_ranger"].animation,
-    "walk": sprite_collection["walk_ranger"].animation
+    "walk": sprite_collection["walk_ranger"].animation,
 }
 
 gMage_animation_list = {
@@ -52,14 +53,19 @@ gMage_animation_list = {
     "single_attack": sprite_collection["singleAttack_mage"].animation,
     "idle": sprite_collection["idle_mage"].animation,
     "knock_down": sprite_collection["knockDown_mage"].animation,
-    "walk": sprite_collection["walk_mage"].animation
+    "walk": sprite_collection["walk_mage"].animation,
 }
 
 gNormalGoblin_animation_list = {
     "idle": sprite_collection["normalGoblinIdle"].animation,
     "attack": sprite_collection["normalGoblinAttack"].animation,
     "death": sprite_collection["normalGoblinDeath"].animation,
-    "walk": sprite_collection["normalGoblinWalk"].animation
+    "walk": sprite_collection["normalGoblinWalk"].animation,
 }
 
-gEntity_animation_dict = {"warrior": gWarrior_animation_list, "ranger": gRanger_animation_list, "mage": gMage_animation_list, "goblin": gNormalGoblin_animation_list}
+gEntity_animation_dict = {
+    "warrior": gWarrior_animation_list,
+    "ranger": gRanger_animation_list,
+    "mage": gMage_animation_list,
+    "goblin": gNormalGoblin_animation_list,
+}

--- a/src/resources.py
+++ b/src/resources.py
@@ -61,3 +61,5 @@ gNormalGoblin_animation_list = {
     "death": sprite_collection["normalGoblinDeath"].animation,
     "walk": sprite_collection["normalGoblinWalk"].animation
 }
+
+gEntity_animation_dict = {"warrior": gWarrior_animation_list, "ranger": gRanger_animation_list, "mage": gMage_animation_list, "goblin": gNormalGoblin_animation_list}

--- a/src/states/BattleActionState.py
+++ b/src/states/BattleActionState.py
@@ -82,6 +82,21 @@ class BattleActionState(BaseState):
 
         self.player.update(dt)
         self.enemy.update(dt)
+
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.update(dt)
+            elif tile.is_occupied() and tile.entity.type == None:
+                tile.entity.update(dt)
+
+        self.remove_timeout_entity()
+
+    def remove_timeout_entity(self):
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.duration == 0:
+                    print("remove second entity for timeout ", tile.index)
+                    tile.remove_second_entity()
     
     def sortEffects(self):
         playerSpeed = self.player.selectedCard.buffed_speed

--- a/src/states/BattleEndState.py
+++ b/src/states/BattleEndState.py
@@ -20,6 +20,11 @@ class BattleEndState(BaseState):
 
         self.player.remove_selected_card()
         self.enemy.remove_selected_card()
+
+        # summon attack
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.bot_action(self.field)
         
     def next_turn(self):
         # Change turn owner

--- a/src/states/BattleEndState.py
+++ b/src/states/BattleEndState.py
@@ -4,6 +4,7 @@ from src.constants import *
 from src.Render import *
 import pygame
 import sys
+import time
 
 class BattleEndState(BaseState):
     def __init__(self):
@@ -33,6 +34,13 @@ class BattleEndState(BaseState):
         # Turn Pass Entity
         self.player.next_turn()
         self.enemy.next_turn()
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.next_turn():
+                    tile.second_entity.ChangeAnimation('death')
+                    tile.remove_second_entity()
+
+
 
     def Exit(self):
         pass
@@ -94,6 +102,21 @@ class BattleEndState(BaseState):
 
         self.player.update(dt)
         self.enemy.update(dt)
+
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.update(dt)
+            elif tile.is_occupied() and tile.entity.type == None:
+                tile.entity.update(dt)
+
+        self.remove_timeout_entity()
+
+    def remove_timeout_entity(self):
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.duration == 0:
+                    print("remove second entity for timeout ", tile.index)
+                    tile.remove_second_entity()
 
     def render(self, screen):
         RenderTurn(screen, 'End State', self.turn, self.currentTurnOwner)

--- a/src/states/BattleInitialState.py
+++ b/src/states/BattleInitialState.py
@@ -78,6 +78,21 @@ class BattleInitialState(BaseState):
 
         self.player.update(dt)
         self.enemy.update(dt)
+
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.update(dt)
+            elif tile.is_occupied() and tile.entity.type == None:
+                tile.entity.update(dt)
+
+        self.remove_timeout_entity()
+
+    def remove_timeout_entity(self):
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.duration == 0:
+                    print("remove second entity for timeout ", tile.index)
+                    tile.remove_second_entity()
         
     def render(self, screen):
         RenderTurn(screen, 'Initial State', self.turn, self.currentTurnOwner)

--- a/src/states/BattleInitialState.py
+++ b/src/states/BattleInitialState.py
@@ -33,7 +33,7 @@ class BattleInitialState(BaseState):
             print("Player's Hand Card: ", card.name)
 
         # Mock buff
-        # mock_buff = Buff(BuffConf('bonus_attack', 1, [1, 0, 0, 0], gBuffIcon_image_list['attack']))
+        # mock_buff = Buff(BuffConf('bonus_attack', 1, [1, 0, 0, 0], 0, gBuffIcon_image_list['attack']))
         # self.player.add_buffs(mock_buff)
         print(f'Player Buffs: {self.player.buffs}')
         print(f'Enemy Buffs: {self.enemy.buffs}')

--- a/src/states/BattlePreparationState.py
+++ b/src/states/BattlePreparationState.py
@@ -25,7 +25,7 @@ class BattlePreparationState(BaseState):
     def initialDraw(self):
         self.player.deck.shuffle()
         for card in self.player.deck.card_deck:
-            if card.name in ["True Damage", "Meteor", "Move 3", "Move 2", "Move 1"]:
+            if card.name in ["Trap", "Meteor", "Move 3", "Move 2", "Move 1"]:
                 self.player.cardsOnHand.append(card)
 
         # self.player.cardsOnHand = self.player.deck.draw(5)

--- a/src/states/BattlePreparationState.py
+++ b/src/states/BattlePreparationState.py
@@ -24,11 +24,11 @@ class BattlePreparationState(BaseState):
     
     def initialDraw(self):
         self.player.deck.shuffle()
-        # for card in self.player.deck.card_deck:
-        #     if card.name in ["Empower", "Ground Defense", "Move 3", "Move 2", "Speed Boost"]:
-        #         self.player.cardsOnHand.append(card)
+        for card in self.player.deck.card_deck:
+            if card.name in ["True Damage", "Meteor", "Move 3", "Move 2", "Move 1"]:
+                self.player.cardsOnHand.append(card)
 
-        self.player.cardsOnHand = self.player.deck.draw(5)
+        # self.player.cardsOnHand = self.player.deck.draw(5)
         self.enemy.deck.shuffle()
         self.enemy.cardsOnHand = self.enemy.deck.draw(5)
 
@@ -38,7 +38,8 @@ class BattlePreparationState(BaseState):
 
         if self.player is None:
             # mock player class
-            job = PlayerClass.WARRIOR
+            # job = PlayerClass.WARRIOR
+            job = PlayerClass.MAGE
             gPlayer_animation_list = gMage_animation_list
             # mock player
             self.player = Player("player", job, gPlayer_animation_list)

--- a/src/states/BattlePreparationState.py
+++ b/src/states/BattlePreparationState.py
@@ -25,7 +25,7 @@ class BattlePreparationState(BaseState):
     def initialDraw(self):
         self.player.deck.shuffle()
         for card in self.player.deck.card_deck:
-            if card.name in ["Trap", "Meteor", "Move 3", "Move 2", "Move 1"]:
+            if card.name in ["Trap", "You shall not pass", "Attack Summon", "Move 2", "Move 1"]:
                 self.player.cardsOnHand.append(card)
 
         # self.player.cardsOnHand = self.player.deck.draw(5)

--- a/src/states/BattleResolveState.py
+++ b/src/states/BattleResolveState.py
@@ -224,8 +224,6 @@ class BattleResolveState(BaseState):
                         critical_buff.value[0] = self.player.selectedCard.attack // 2
                         self.player.add_buff(critical_buff)
                 # MAGE CLASS
-                case EffectType.TRUE_DAMAGE:
-                    pass
                 case EffectType.NEXT_MULTI:
                     pass
                 # BOSSES

--- a/src/states/BattleResolveState.py
+++ b/src/states/BattleResolveState.py
@@ -32,6 +32,13 @@ class BattleResolveState(BaseState):
     def Exit(self):
         pass
 
+    def remove_timeout_entity(self):
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.duration == 0:
+                    print("remove second entity for timeout ", tile.index)
+                    tile.remove_second_entity()
+
     def update(self, dt, events):
         for event in events:
             if event.type == pygame.QUIT:
@@ -88,6 +95,14 @@ class BattleResolveState(BaseState):
 
         self.player.update(dt)
         self.enemy.update(dt)
+
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.update(dt)
+            elif tile.is_occupied() and tile.entity.type == None:
+                tile.entity.update(dt)
+
+        self.remove_timeout_entity()
         
     def resolveCardEffect(self, effect, effectOwner):
         if not ((effectOwner == PlayerType.PLAYER and self.player.stunt == True) or (effectOwner == PlayerType.ENEMY and self.enemy.stunt == True)):

--- a/src/states/BattleResolveState.py
+++ b/src/states/BattleResolveState.py
@@ -91,7 +91,7 @@ class BattleResolveState(BaseState):
         
     def resolveCardEffect(self, effect, effectOwner):
         match effect.type:
-            case EffectType.ATTACK | EffectType.ATTACK_SELF_BUFF | EffectType.ATTACK_OPPO_BUFF:
+            case EffectType.ATTACK | EffectType.ATTACK_SELF_BUFF | EffectType.ATTACK_OPPO_BUFF | EffectType.TRUE_DAMAGE:
                 g_state_manager.Change(SelectionState.ATTACK, {
                     'player': self.player,
                     'enemy': self.enemy,
@@ -170,8 +170,6 @@ class BattleResolveState(BaseState):
             case EffectType.CRITICAL:
                 pass
             # MAGE CLASS
-            case EffectType.TRUE_DAMAGE:
-                pass
             case EffectType.NEXT_MULTI:
                 pass
             # BOSSES

--- a/src/states/BattleResolveState.py
+++ b/src/states/BattleResolveState.py
@@ -209,6 +209,16 @@ class BattleResolveState(BaseState):
             case EffectType.KAMIKAZE:
                 pass
             case EffectType.SPAWN:
+                g_state_manager.Change(SelectionState.SPAWN, {
+                    'player': self.player,
+                    'enemy': self.enemy,
+                    'field': self.field,
+                    'turn': self.turn,
+                    'currentTurnOwner': self.currentTurnOwner,
+                    'effectOrder': self.effectOrder,
+                    'effect': effect,
+                    'effectOwner': effectOwner
+                })
                 pass
             case EffectType.HEAL:
                 pass

--- a/src/states/BattleSelectState.py
+++ b/src/states/BattleSelectState.py
@@ -71,6 +71,21 @@ class BattleSelectState(BaseState):
             
         self.player.update(dt)
         self.enemy.update(dt)
+
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.update(dt)
+            elif tile.is_occupied() and tile.entity.type == None:
+                tile.entity.update(dt)
+
+        self.remove_timeout_entity()
+
+    def remove_timeout_entity(self):
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.duration == 0:
+                    print("remove second entity for timeout ", tile.index)
+                    tile.remove_second_entity()
         
     def change_selection(self, newIndex):
         self.player.cardsOnHand[self.selected_index].isSelected = False

--- a/src/states/SelectAttackState.py
+++ b/src/states/SelectAttackState.py
@@ -109,6 +109,8 @@ class SelectAttackState(BaseState):
                             if self.field[self.avilableAttackTile[self.selectAttackTile]].is_occupied():
                                 self.player.ChangeAnimation("multi_attack")
                                 self.enemy.ChangeAnimation("death")
+                                if self.effect.type == EffectType.TRUE_DAMAGE:
+                                    self.enemy.defense = 0
                                 damage = self.player.attack - self.field[self.avilableAttackTile[self.selectAttackTile]].entity.defense
                                 if damage > 0:
                                     # ATTACK HIT

--- a/src/states/SelectAttackState.py
+++ b/src/states/SelectAttackState.py
@@ -87,6 +87,13 @@ class SelectAttackState(BaseState):
     def Exit(self):
         pass
 
+    def remove_timeout_entity(self):
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.duration == 0:
+                    print("remove second entity for timeout ", tile.index)
+                    tile.remove_second_entity()
+
     def update(self, dt, events):
         for event in events:
             if event.type == pygame.QUIT:
@@ -188,6 +195,14 @@ class SelectAttackState(BaseState):
 
         self.player.update(dt)
         self.enemy.update(dt)
+
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.update(dt)
+            elif tile.is_occupied() and tile.entity.type == None:
+                tile.entity.update(dt)
+
+        self.remove_timeout_entity()
 
     def getBuffFromEffect(self, effect):
         if effect.buffName:

--- a/src/states/SelectAttackState.py
+++ b/src/states/SelectAttackState.py
@@ -119,10 +119,9 @@ class SelectAttackState(BaseState):
                     if self.selectAttackTile>=0 and self.effect.maxRange>0:
                         attacking_field = self.field[self.availableAttackTile[self.selectAttackTile]]
                         defender = attacking_field.entity
-                        if self.effect.type == EffectType.TRUE_DAMAGE:
-                            defender.defense = 0
                         # ATTACK
                         if attacking_field.is_occupied():
+                            # RENDER ATTACKER ANIMATION
                             if self.effectOwner == PlayerType.PLAYER:
                                 self.player.ChangeAnimation("multi_attack")
                                 attacker = self.player
@@ -130,7 +129,13 @@ class SelectAttackState(BaseState):
                                 self.enemy.ChangeAnimation("attack")
                                 attacker = self.enemy
                             
-                            damage = attacker.attack - defender.defense
+                            # Damage Calculation
+                            if self.effect.type == EffectType.TRUE_DAMAGE:
+                                damage = attacker.attack
+                            else:
+                                damage = attacker.attack - defender.defense
+
+                            # Check For Evade Buff
                             is_evade = False
                             for buff in defender.buffs:
                                 if buff.type == BuffType.EVADE:
@@ -143,7 +148,7 @@ class SelectAttackState(BaseState):
                                 defender.health -= damage
                                 defender.stunt = True
                                 print(f'{defender} takes {damage} damage')
-                                # RENDER ANIMATION
+                                # RENDER DEFENDER ANIMATION
                                 if self.effectOwner == PlayerType.PLAYER:
                                     self.enemy.ChangeAnimation("death")
                                 elif self.effectOwner == PlayerType.ENEMY:

--- a/src/states/SelectAttackState.py
+++ b/src/states/SelectAttackState.py
@@ -160,6 +160,9 @@ class SelectAttackState(BaseState):
                                 gSounds['block'].play()
                                 print(f'{defender} takes no damage')
                             defender.print_stats()
+                        elif attacking_field.second_entity:
+                            if attacking_field.second_entity.side != self.effectOwner:
+                                attacking_field.second_entity.take_damage(attacker.attack)
                         else:
                             print("no entity on the targeted tile")
                     else:

--- a/src/states/SelectBuffState.py
+++ b/src/states/SelectBuffState.py
@@ -86,6 +86,13 @@ class SelectBuffState(BaseState):
     def Exit(self):
         pass
 
+    def remove_timeout_entity(self):
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.duration == 0:
+                    print("remove second entity for timeout ", tile.index)
+                    tile.remove_second_entity()
+
     def update(self, dt, events):
         for event in events:
             if event.type == pygame.QUIT:
@@ -159,6 +166,14 @@ class SelectBuffState(BaseState):
 
         self.player.update(dt)
         self.enemy.update(dt)
+
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.update(dt)
+            elif tile.is_occupied() and tile.entity.type == None:
+                tile.entity.update(dt)
+
+        self.remove_timeout_entity()
 
     def getBuffFromEffect(self, effect):
         if effect.buffName:

--- a/src/states/SelectMoveState.py
+++ b/src/states/SelectMoveState.py
@@ -28,12 +28,12 @@ class SelectMoveState(BaseState):
             self.leftMinTileIndex = self.player.fieldTile_index - self.effect.minRange
             self.leftMaxTileIndex = self.player.fieldTile_index - self.effect.maxRange
             self.rightMinTileIndex = self.player.fieldTile_index + self.effect.minRange
-            self.rightMaxTileIndex = self.player.fieldTile_index + self.effect.maxRange 
+            self.rightMaxTileIndex = self.player.fieldTile_index + self.effect.maxRange
         elif self.effectOwner == PlayerType.ENEMY: 
             self.leftMinTileIndex = self.enemy.fieldTile_index - self.effect.minRange
             self.leftMaxTileIndex = self.enemy.fieldTile_index - self.effect.maxRange
             self.rightMinTileIndex = self.enemy.fieldTile_index + self.effect.minRange
-            self.rightMaxTileIndex = self.enemy.fieldTile_index + self.effect.maxRange        
+            self.rightMaxTileIndex = self.enemy.fieldTile_index + self.effect.maxRange
 
         if self.leftMinTileIndex < 0:
             self.leftMinTileIndex = 0

--- a/src/states/SelectMoveState.py
+++ b/src/states/SelectMoveState.py
@@ -5,6 +5,7 @@ from src.constants import *
 from src.Render import *
 import pygame
 import sys
+import time
 
 class SelectMoveState(BaseState):
     def __init__(self):
@@ -27,11 +28,20 @@ class SelectMoveState(BaseState):
 
         if self.effectOwner == PlayerType.PLAYER:
             for buff in self.player.buffs:
-                if buff.name == "Stop Movement":
+                if buff.type == BuffType.STOP_MOVEMENT:
                     print("can not move due to debuff")
-                    self.leftSkip = True
-                    self.rightSkip = True
-                    break
+                    self.player.ChangeAnimation('knock_down')
+                    time.sleep(1)
+                    # self.leftSkip = True
+                    # self.rightSkip = True
+                    g_state_manager.Change(BattleState.RESOLVE_PHASE, {
+                            'player': self.player,
+                            'enemy': self.enemy,
+                            'field': self.field,
+                            'turn': self.turn,
+                            'currentTurnOwner': self.currentTurnOwner,
+                            'effectOrder': self.effectOrder
+                        })
             startIndex = self.player.fieldTile_index
             self.leftMinTileIndex = self.player.fieldTile_index - self.effect.minRange
             self.leftMaxTileIndex = self.player.fieldTile_index - self.effect.maxRange
@@ -40,11 +50,20 @@ class SelectMoveState(BaseState):
             print("should still run this code though")
         elif self.effectOwner == PlayerType.ENEMY:
             for buff in self.enemy.buffs:
-                if buff.name == "Stop Movement":
+                if buff.type == BuffType.STOP_MOVEMENT:
                     print("can not move due to debuff")
-                    self.leftSkip = True
-                    self.rightSkip = True
-                    break
+                    self.enemy.ChangeAnimation('death')
+                    time.sleep(1)
+                    # self.leftSkip = True
+                    # self.rightSkip = True
+                    g_state_manager.Change(BattleState.RESOLVE_PHASE, {
+                            'player': self.player,
+                            'enemy': self.enemy,
+                            'field': self.field,
+                            'turn': self.turn,
+                            'currentTurnOwner': self.currentTurnOwner,
+                            'effectOrder': self.effectOrder
+                        })
             startIndex = self.enemy.fieldTile_index
             self.leftMinTileIndex = self.enemy.fieldTile_index - self.effect.minRange
             self.leftMaxTileIndex = self.enemy.fieldTile_index - self.effect.maxRange

--- a/src/states/SelectPullState.py
+++ b/src/states/SelectPullState.py
@@ -65,8 +65,17 @@ class SelectPullState(BaseState):
         self.player.display_stats()
         self.enemy.display_stats()
 
+        
+
     def Exit(self):
         pass
+
+    def remove_timeout_entity(self):
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.duration == 0:
+                    print("remove second entity for timeout ", tile.index)
+                    tile.remove_second_entity()
 
     def update(self, dt, events):
         for event in events:
@@ -138,6 +147,14 @@ class SelectPullState(BaseState):
 
         self.player.update(dt)
         self.enemy.update(dt)
+
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.update(dt)
+            elif tile.is_occupied() and tile.entity.type == None:
+                tile.entity.update(dt)
+
+        self.remove_timeout_entity()
         
     def render(self, screen):
         RenderTurn(screen, 'SelectPullState', self.turn, self.currentTurnOwner)

--- a/src/states/SelectPushState.py
+++ b/src/states/SelectPushState.py
@@ -68,6 +68,13 @@ class SelectPushState(BaseState):
     def Exit(self):
         pass
 
+    def remove_timeout_entity(self):
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.duration == 0:
+                    print("remove second entity for timeout ", tile.index)
+                    tile.remove_second_entity()
+
     def update(self, dt, events):
         for event in events:
             if event.type == pygame.QUIT:
@@ -138,6 +145,14 @@ class SelectPushState(BaseState):
 
         self.player.update(dt)
         self.enemy.update(dt)
+
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.update(dt)
+            elif tile.is_occupied() and tile.entity.type == None:
+                tile.entity.update(dt)
+
+        self.remove_timeout_entity()
         
     def render(self, screen):
         RenderTurn(screen, 'SelectPushState', self.turn, self.currentTurnOwner)

--- a/src/states/SelectSpawnState.py
+++ b/src/states/SelectSpawnState.py
@@ -116,6 +116,7 @@ class SelectSpawnState(BaseState):
                         if self.selectSpawnTile>=0 and self.effect.maxRange>0:
                             if not self.field[self.availableSpawnTile[self.selectSpawnTile]].is_occupied():
                                 spawn = SubEntity(SUB_ENTITY[self.effect.spawn], PlayerType.PLAYER)
+                                spawn.fieldTile_index = self.availableSpawnTile[self.selectSpawnTile]
                                 spawn_x = self.field[self.availableSpawnTile[self.selectSpawnTile]].x
                                 self.field[self.availableSpawnTile[self.selectSpawnTile]].place_entity(spawn, spawn_x)
                                 print(f"{self.effectOwner} summon {spawn.name}")

--- a/src/states/SelectSpawnState.py
+++ b/src/states/SelectSpawnState.py
@@ -77,8 +77,17 @@ class SelectSpawnState(BaseState):
         self.player.display_stats()
         self.enemy.display_stats()
 
+        
+
     def Exit(self):
         pass
+
+    def remove_timeout_entity(self):
+        for tile in self.field:
+            if tile.is_second_entity():
+                if tile.second_entity.duration == 0:
+                    print("remove second entity for timeout ", tile.index)
+                    tile.remove_second_entity()
 
     def update(self, dt, events):
         for event in events:
@@ -147,6 +156,14 @@ class SelectSpawnState(BaseState):
 
         self.player.update(dt)
         self.enemy.update(dt)
+
+        for tile in self.field:
+            if tile.second_entity:
+                tile.second_entity.update(dt)
+            elif tile.is_occupied() and tile.entity.type == None:
+                tile.entity.update(dt)
+
+        self.remove_timeout_entity()
 
     # def getBuffListFromEffect(self, effect):
     #     buffList = []


### PR DESCRIPTION
Implement Mage card logic (  ** still didn't implement mage passive ** )
- True damage : ignore defense
- Meteor : add dot damage for fire debuff
- Trap ( new version of "shadow clone") : place trap on field. trap will trigger if enemy step on it. Player can step on their own trap.
- Summon ( new version of "sweet dream") : summon sub_entity on field. summon will attack every end phase.
- Stop movement : add stop movement debuff ( still have issue animation que for skip move state )

Trap and summon is a "Sub Entity". sub entity can be place in the same field with entity ( I use "second_entity" attribute for field )
Both summon and trap can be attacked.

** these effects is really hard to test, so there might be a lot of bug **